### PR TITLE
[Certora L-06] required delay for hyperCore state reads

### DIFF
--- a/src/interfaces/IStakingCore.sol
+++ b/src/interfaces/IStakingCore.sol
@@ -22,6 +22,7 @@ interface IStakingCore {
     error StakingPaused();
     error ElapsedTimeCannotBeZero();
     error FailedToSendFromWithdrawManager();
+    error ExchangeRatioUpdateTooSoon(uint256 blocksRequired, uint256 blocksPassed);
 
     /* ========== EVENTS ========== */
 

--- a/test/StakingCore.t.sol
+++ b/test/StakingCore.t.sol
@@ -18,6 +18,7 @@ contract StakingCoreTest is BaseTest {
 
         vm.prank(admin);
         vm.warp(block.timestamp + 1 days);
+        vm.roll(block.number + 5);
         stakingCore.updateExchangeRatio();
 
         assertEq(stakingCore.exchangeRatio(), 1 ether);
@@ -29,6 +30,7 @@ contract StakingCoreTest is BaseTest {
         // 1% APR
         DelegatorSummaryMock(DELEGATOR_SUMMARY_PRECOMPILE_ADDRESS).setDelegatorSummary(address(stakingCore), 0.01 ether, 0, 0);
         vm.warp(block.timestamp + 365 days);
+        vm.roll(block.number + 5);
 
         vm.prank(admin);
         stakingCore.updateExchangeRatio();
@@ -116,6 +118,31 @@ contract StakingCoreTest is BaseTest {
             400,
             true
         );
+    }
+
+    function test_ExchangeRatioUpdateGuard() public {
+        test_stake();
+        vm.warp(block.timestamp + 1 days);
+
+        vm.startPrank(user);
+        beHYPE.approve(address(withdrawManager), 1 ether);
+        withdrawManager.withdraw(1 ether, false);
+        vm.stopPrank();
+
+        vm.startPrank(admin);
+        stakingCore.depositToHyperCore(0.000001 ether);
+
+        vm.expectRevert(abi.encodeWithSelector(IStakingCore.ExchangeRatioUpdateTooSoon.selector, 5, 0));
+        stakingCore.updateExchangeRatio();
+
+        stakingCore.withdrawFromHyperCore(0.000001 ether);
+
+        vm.roll(block.number + 4);
+        vm.expectRevert(abi.encodeWithSelector(IStakingCore.ExchangeRatioUpdateTooSoon.selector, 5, 4));
+        stakingCore.updateExchangeRatio();
+
+        vm.roll(block.number + 5);
+        stakingCore.updateExchangeRatio();
     }
 
 }

--- a/test/WithdrawManager.t.sol
+++ b/test/WithdrawManager.t.sol
@@ -85,6 +85,7 @@ contract WithdrawManagerTest is BaseTest {
         // update exchange rate to 1 BeHYPE = 2 HYPE
         DelegatorSummaryMock(DELEGATOR_SUMMARY_PRECOMPILE_ADDRESS).setDelegatorSummary(address(stakingCore), 90 ether, 0, 0);
         vm.warp(block.timestamp + (365 days * 100));
+        vm.roll(block.number + 5);
         vm.prank(admin);
         stakingCore.updateExchangeRatio();
         assertEq(stakingCore.BeHYPEToHYPE(1 ether), 2 ether);
@@ -117,6 +118,7 @@ contract WithdrawManagerTest is BaseTest {
         // update exchange rate to 1 BeHYPE = 2 HYPE
         DelegatorSummaryMock(DELEGATOR_SUMMARY_PRECOMPILE_ADDRESS).setDelegatorSummary(address(stakingCore), 100 ether, 0, 0);
         vm.warp(block.timestamp + (365 days * 100));
+        vm.roll(block.number + 5);
         vm.prank(admin);
         stakingCore.updateExchangeRatio();
         assertEq(stakingCore.BeHYPEToHYPE(1 ether), 2 ether);
@@ -189,10 +191,11 @@ contract WithdrawManagerTest is BaseTest {
         assertEq(stakingCore.getTotalProtocolHype(), 100 ether);
 
         mockDepositToHyperCore(96 ether);
+        vm.roll(block.number + 5);
 
-        // update exchange rate to 1 BeHYPE = 2 HYPE
         DelegatorSummaryMock(DELEGATOR_SUMMARY_PRECOMPILE_ADDRESS).setDelegatorSummary(address(stakingCore), 100 ether, 0, 0);
         vm.warp(block.timestamp + (365 days * 100));
+        vm.roll(block.number + 5);
         vm.prank(admin);
         stakingCore.updateExchangeRatio();
         assertEq(stakingCore.BeHYPEToHYPE(1 ether), 2 ether);


### PR DESCRIPTION
### Description
On the L1, each block reads the Core state for the end of the previous block. This creates a potential issue in which updateExchangeRatio returns an incorrect ratio due to unprocessed deposits to the spot balance.
For instance, there could be 50e18 Hype currently in the StakingCore. If the admin calls depositToHyperCore() in block 7, passing 20 tokens, and also executes updateExchangeRatio() in that block, these 20 tokens will not be read because they are locked on the system contract on the EVM and they are also not yet assigned on the core spot balances. An analogical issue also exists for withdrawFromHyperCore().

### Fix
Save the block.number when depositToHyperCore() and withdrawFromHyperCore() have been invoked and ensuring a minBlocksPassed duration, in which the updateExchangeRatio() will not be callable, so that a proper state is fetched.