### PR TITLE
[Certora I-10] emergency withdraw function

### DIFF
--- a/src/StakingCore.sol
+++ b/src/StakingCore.sol
@@ -191,6 +191,13 @@ contract StakingCore is IStakingCore, Initializable, UUPSUpgradeable, PausableUp
         emit HyperCoreStakingWithdraw(amount);
     }
 
+    function emergencyWithdrawFromStaking(uint256 amount) external {
+        if (!roleRegistry.hasRole(roleRegistry.PROTOCOL_GUARDIAN(), msg.sender)) revert NotAuthorized();
+        
+        _encodeAction(5, abi.encode(_convertTo8Decimals(amount)));
+        emit HyperCoreStakingWithdraw(amount);
+    }
+
     function delegateTokens(address validator, uint256 amount, bool isUndelegate) external {
         if (!roleRegistry.hasRole(roleRegistry.PROTOCOL_ADMIN(), msg.sender)) revert NotAuthorized();
         

--- a/src/interfaces/IStakingCore.sol
+++ b/src/interfaces/IStakingCore.sol
@@ -191,6 +191,16 @@ interface IStakingCore {
     function withdrawFromStaking(uint256 amount) external;
 
     /**
+     * @notice Emergency withdrawal of HYPE from staking via CoreWriter Action 5
+     * @param amount The amount of HYPE to withdraw in wei
+     * @dev Only callable by accounts with PROTOCOL_GUARDIAN role
+     * @dev Bypasses cooldown and pending withdrawal restrictions
+     * @dev Sends Action 5 to CoreWriter for HyperCore processing
+     * @dev Emits StakingWithdraw event
+     */
+    function emergencyWithdrawFromStaking(uint256 amount) external;
+
+    /**
      * @notice Delegates or undelegates tokens via CoreWriter Action 3
      * @param validator The validator address to delegate/undelegate from
      * @param amount The amount of tokens to delegate/undelegate in wei


### PR DESCRIPTION
## I-10. Emergency withdrawing from core staking balances is restricted by pending withdraws
### Description
The newly [implemented check](https://github.com/etherfi-protocol/BeHYPE/blob/audit-fixes/src/StakingCore.sol#L183) in withdrawFromStaking() is meant to guard in case the PROTOCOL_ADMIN() role is compromised. It restricts the withdrawal amounts up to the hypeRequestedForWithdraw amounts. This creates another restriction where the protocol multisig will not be able to emergency withdraw if there are no pending withdrawal requests, even if it the cooldown is disabled

### Fix
added a emergency withdraw  function