### PR TITLE
adding deployer slot

### DIFF
--- a/src/BeHYPE.sol
+++ b/src/BeHYPE.sol
@@ -65,7 +65,7 @@ contract BeHYPE is IBeHYPEToken, ERC20PermitUpgradeable, UUPSUpgradeable {
         emit WithdrawManagerUpdated(withdrawManager);
     }
 
-    function setFinalizerUser(address _finalizerUser) external {
+    function setFinalizer(address _finalizerUser) external {
         if (!roleRegistry.hasRole(roleRegistry.PROTOCOL_GUARDIAN(), msg.sender)) revert Unauthorized();
         
         bytes32 slot = HYPERCORE_DEPLOYER;
@@ -76,7 +76,7 @@ contract BeHYPE is IBeHYPEToken, ERC20PermitUpgradeable, UUPSUpgradeable {
         emit FinalizerUserUpdated(_finalizerUser);
     }
 
-    function getFinalizerUser() external view returns (address) {
+    function getFinalizer() external view returns (address) {
         address finalizerUser;
         bytes32 slot = HYPERCORE_DEPLOYER;
         assembly {

--- a/src/interfaces/IBeHYPE.sol
+++ b/src/interfaces/IBeHYPE.sol
@@ -30,20 +30,20 @@ interface IBeHYPEToken is IERC20 {
     function burn(address from, uint256 amount) external;
 
     /**
-     * @notice Sets the finalizer user address
-     * @dev Only callable by PROTOCOL_GUARDIAN role. The finalizer user address is stored
+     * @notice Sets the finalizer / hyperCore deployer address
+     * @dev Only callable by PROTOCOL_GUARDIAN role. The finalizer address is stored
      *      in the storage slot at keccak256("HyperCore deployer") as required for
      *      contracts deployed by another contract (e.g. create2 via a multisig).
      * https://hyperliquid.gitbook.io/hyperliquid-docs/for-developers/hyperevm/hypercore-less-than-greater-than-hyperevm-transfers#linking-core-and-evm-spot-assets
      * @param _finalizerUser The address of the finalizer user
      */
-    function setFinalizerUser(address _finalizerUser) external;
+    function setFinalizer(address _finalizerUser) external;
 
     /**
-     * @notice Gets the finalizer user address
+     * @notice Gets the finalizer / hyperCore deployer address
      * @dev Returns the address stored in the storage slot at keccak256("HyperCore deployer")
      * https://hyperliquid.gitbook.io/hyperliquid-docs/for-developers/hyperevm/hypercore-less-than-greater-than-hyperevm-transfers#linking-core-and-evm-spot-assets
-     * @return The address of the finalizer user
+     * @return The address of the finalizer / hyperCore deployer
      */
-    function getFinalizerUser() external view returns (address);
+    function getFinalizer() external view returns (address);
 }

--- a/test/BeHYPE.t.sol
+++ b/test/BeHYPE.t.sol
@@ -210,18 +210,18 @@ contract BeHYPETest is BaseTest {
     function test_FinalizerUser() public {
         address finalizerUser = makeAddr("finalizer");
         
-        assertEq(beHYPE.getFinalizerUser(), address(0));
+        assertEq(beHYPE.getFinalizer(), address(0));
         
         vm.prank(user);
         vm.expectRevert(abi.encodeWithSelector(IBeHYPEToken.Unauthorized.selector));
-        beHYPE.setFinalizerUser(finalizerUser);
+        beHYPE.setFinalizer(finalizerUser);
         
         vm.prank(admin);
         vm.expectEmit(true, false, false, true);
         emit FinalizerUserUpdated(finalizerUser);
-        beHYPE.setFinalizerUser(finalizerUser);
+        beHYPE.setFinalizer(finalizerUser);
         
-        assertEq(beHYPE.getFinalizerUser(), finalizerUser);
+        assertEq(beHYPE.getFinalizer(), finalizerUser);
         
         bytes32 slot = keccak256("HyperCore deployer");
         bytes32 storedValue = vm.load(address(beHYPE), slot);


### PR DESCRIPTION
In order for the token contract to linked with a hyperCore deployment, the contract must store the hyperCore deployer for linking

https://hyperliquid.gitbook.io/hyperliquid-docs/for-developers/hyperevm/hypercore-less-than-greater-than-hyperevm-transfers#linking-core-and-evm-spot-assets