### PR TITLE
rate limiter configuration fix

### DIFF
--- a/src/WithdrawManager.sol
+++ b/src/WithdrawManager.sol
@@ -64,7 +64,7 @@ contract WithdrawManager is
         address _beHypeToken,
         address _stakingCore,
         uint256 _bucketCapacity,
-        uint64 _bucketRefillRate
+        uint256 _bucketRefillRate
     ) public initializer {
         __UUPSUpgradeable_init();
         __ReentrancyGuard_init();
@@ -80,7 +80,7 @@ contract WithdrawManager is
 
         instantWithdrawalLimit = BucketLimiter.create(
             _convertToBucketUnit(_bucketCapacity, Math.Rounding.Floor), 
-            _bucketRefillRate
+            _convertToBucketUnit(_bucketRefillRate, Math.Rounding.Floor)
         );
 
         withdrawalQueue.push(WithdrawalEntry({
@@ -195,9 +195,11 @@ contract WithdrawManager is
         emit InstantWithdrawalCapacityUpdated(capacity);
     }
 
-    function setInstantWithdrawalRefillRatePerSecond(uint64 refillRate) external {
+    function setInstantWithdrawalRefillRatePerSecond(uint256 refillRate) external {
         if (!roleRegistry.hasRole(roleRegistry.PROTOCOL_ADMIN(), msg.sender)) revert NotAuthorized();
-        BucketLimiter.setRefillRate(instantWithdrawalLimit, refillRate);
+        
+        uint64 bucketUnit = _convertToBucketUnit(refillRate, Math.Rounding.Floor);
+        BucketLimiter.setRefillRate(instantWithdrawalLimit, bucketUnit);
         emit InstantWithdrawalRefillRateUpdated(refillRate);
     }
 

--- a/src/interfaces/IWithdrawManager.sol
+++ b/src/interfaces/IWithdrawManager.sol
@@ -68,7 +68,7 @@ interface IWithdrawManager {
     
     event InstantWithdrawalCapacityUpdated(uint256 capacity);
     
-    event InstantWithdrawalRefillRateUpdated(uint64 refillRate);
+    event InstantWithdrawalRefillRateUpdated(uint256 refillRate);
     
     /* ========== MAIN FUNCTIONS ========== */
     
@@ -155,6 +155,6 @@ interface IWithdrawManager {
      * @param refillRate The new instant withdrawal refill rate per second
      * @dev Only callable by the protocol admin
      */
-    function setInstantWithdrawalRefillRatePerSecond(uint64 refillRate) external;
+    function setInstantWithdrawalRefillRatePerSecond(uint256 refillRate) external;
     
 }

--- a/test/Base.t.sol
+++ b/test/Base.t.sol
@@ -98,7 +98,7 @@ contract BaseTest is Test {
                 address(beHYPE),
                 address(stakingCore),
                 10 ether,
-                1 days
+                0.1 ether
             )
         ))));
 


### PR DESCRIPTION
I mistook the BucketLimiter `refillRate` as a value in seconds, but it actually in units per second. We should also use the bucket rate limit conversion like we do for setting the `capacity` of the bucket for consistency