### PR TITLE
change compiler version

### DIFF
--- a/src/BeHYPE.sol
+++ b/src/BeHYPE.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.26;
+pragma solidity ^0.8.24;
 
 import {ERC20PermitUpgradeable} from "@openzeppelin/contracts-upgradeable/token/ERC20/extensions/ERC20PermitUpgradeable.sol";
 import {UUPSUpgradeable} from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";

--- a/src/BeHYPETimelock.sol
+++ b/src/BeHYPETimelock.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.26;
+pragma solidity ^0.8.24;
 
 import "@openzeppelin/contracts/governance/TimelockController.sol";
 

--- a/src/RoleRegistry.sol
+++ b/src/RoleRegistry.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.26;
+pragma solidity ^0.8.24;
 
 import {Ownable2StepUpgradeable} from "@openzeppelin-upgradeable/access/Ownable2StepUpgradeable.sol";
 import {UUPSUpgradeable, Initializable} from "@openzeppelin-upgradeable/proxy/utils/UUPSUpgradeable.sol";

--- a/src/StakingCore.sol
+++ b/src/StakingCore.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.26;
+pragma solidity ^0.8.24;
 
 /* ========== IMPORTS ========== */
 

--- a/src/WithdrawManager.sol
+++ b/src/WithdrawManager.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.26;
+pragma solidity ^0.8.24;
 
 import {ReentrancyGuardUpgradeable} from "@openzeppelin/contracts-upgradeable/utils/ReentrancyGuardUpgradeable.sol";
 import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";

--- a/src/interfaces/IBeHYPE.sol
+++ b/src/interfaces/IBeHYPE.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.26;
+pragma solidity ^0.8.24;
 
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 

--- a/src/interfaces/IRoleRegistry.sol
+++ b/src/interfaces/IRoleRegistry.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.26;
+pragma solidity ^0.8.24;
 
 import {IWithdrawManager} from "./IWithdrawManager.sol";
 import {IStakingCore} from "./IStakingCore.sol";

--- a/src/interfaces/IStakingCore.sol
+++ b/src/interfaces/IStakingCore.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.26;
+pragma solidity ^0.8.24;
 
 import {IRoleRegistry} from "./IRoleRegistry.sol";
 import {IBeHYPEToken} from "./IBeHype.sol";

--- a/src/interfaces/IWithdrawManager.sol
+++ b/src/interfaces/IWithdrawManager.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.26;
+pragma solidity ^0.8.24;
 
 import {IRoleRegistry} from "./IRoleRegistry.sol";
 import {IBeHYPEToken} from "./IBeHYPE.sol";

--- a/src/lib/UUPSProxy.sol
+++ b/src/lib/UUPSProxy.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.28;
+pragma solidity ^0.8.24;
 
 import { ERC1967Proxy } from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
 


### PR DESCRIPTION
Etherscan is unable to verify our RoleRegistry contract on solidity version ^0.8.26; or  ^0.8.28;. We need to reduce the version so to allow for the contract to be verify as verified contracts are required to be put into production